### PR TITLE
declaration-colon-space-after only for single line

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     ],
     "declaration-block-trailing-semicolon": "always",
     "declaration-colon-newline-after": "always-multi-line",
-    "declaration-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-no-important": true,
     "font-family-name-quotes": "always-unless-keyword",


### PR DESCRIPTION
Sometimes statements can to be wrapped over multiple lines. Then the extra space after : should not be there.
Eg.

```
 background:
                linear-gradient (
                to bottom,
                $platform-border-color 0%,
                $white 80%
            );
```
